### PR TITLE
ci: point semantic release to repo token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,4 +18,4 @@ jobs:
         name: Create release
         id: semantic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
make sure that semantic release uses the REPO_TOKEN secret to access the repositorties